### PR TITLE
Refactor summary cards into partial

### DIFF
--- a/templates/core/partials/summary_card.html
+++ b/templates/core/partials/summary_card.html
@@ -1,0 +1,15 @@
+<div class="col-md-3">
+    <div class="card bg-{{ color }} text-white">
+        <div class="card-body">
+            <div class="d-flex justify-content-between">
+                <div>
+                    <h4 class="card-title">{{ value }}</h4>
+                    <p class="card-text">{{ title }}</p>
+                </div>
+                <div class="align-self-center">
+                    <i class="bi {{ icon }} fs-1"></i>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/core/user_activity_dashboard.html
+++ b/templates/core/user_activity_dashboard.html
@@ -32,71 +32,13 @@
             
             <!-- Summary Cards -->
             <div class="row mb-4">
-                <div class="col-md-3">
-                    <div class="card bg-primary text-white">
-                        <div class="card-body">
-                            <div class="d-flex justify-content-between">
-                                <div>
-                                    <h4 class="card-title">{{ total_activities }}</h4>
-                                    <p class="card-text">Total Activities</p>
-                                </div>
-                                <div class="align-self-center">
-                                    <i class="bi bi-activity fs-1"></i>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                
-                <div class="col-md-3">
-                    <div class="card bg-success text-white">
-                        <div class="card-body">
-                            <div class="d-flex justify-content-between">
-                                <div>
-                                    <h4 class="card-title">{{ unique_users }}</h4>
-                                    <p class="card-text">Active Users</p>
-                                </div>
-                                <div class="align-self-center">
-                                    <i class="bi bi-people fs-1"></i>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                
-                <div class="col-md-3">
-                    <div class="card bg-info text-white">
-                        <div class="card-body">
-                            <div class="d-flex justify-content-between">
-                                <div>
-                                    <h4 class="card-title">{{ days }}</h4>
-                                    <p class="card-text">Days Analyzed</p>
-                                </div>
-                                <div class="align-self-center">
-                                    <i class="bi bi-calendar-range fs-1"></i>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                
-                <div class="col-md-3">
-                    <div class="card bg-warning text-white">
-                        <div class="card-body">
-                            <div class="d-flex justify-content-between">
-                                <div>
-                                    <h4 class="card-title">{{ action_counts|length }}</h4>
-                                    <p class="card-text">Action Types</p>
-                                </div>
-                                <div class="align-self-center">
-                                    <i class="bi bi-list-ul fs-1"></i>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                {% include "core/partials/summary_card.html" with value=total_activities title="Total Activities" icon="bi-activity" color="primary" %}
+                {% include "core/partials/summary_card.html" with value=unique_users title="Active Users" icon="bi-people" color="success" %}
+                {% include "core/partials/summary_card.html" with value=days title="Days Analyzed" icon="bi-calendar-range" color="info" %}
+                {% include "core/partials/summary_card.html" with value=action_counts|length title="Action Types" icon="bi-list-ul" color="warning" %}
             </div>
-            
+
+
             <div class="row">
                 <!-- Action Breakdown -->
                 <div class="col-md-6 mb-4">


### PR DESCRIPTION
## Summary
- extract metric summary card into reusable `summary_card` partial
- use the new partial in the user activity dashboard

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests'; ModuleNotFoundError: No module named 'pandas')*
- `pip install requests pandas` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f62c6c908321b3203d6472a5e116